### PR TITLE
Standardize spelling of "Tokenizer" with Z throughout the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
 
 ## uncomment the following lines to override the default test script
 #script:
-#  - julia -e 'Pkg.clone(pwd()); Pkg.build("WordTokenizers"); Pkg.test("WordTokenisers"; coverage=true)'
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("WordTokenizers"); Pkg.test("WordTokenizers"; coverage=true)'
 after_success:
   # push coverage results to Coveralls
   - julia -e 'cd(Pkg.dir("WordTokenizers")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 Copyright (C) 2001-2017 Lyndon White aka @oxinabox (Everything else, Apache 2)  
-Copyright (C) 2001-2017 NLTK Project (ImprovedPennTokeniser, Apache 2)   
-Copyright (C) 1995 Robert MacIntyre (PennTokeniser, Unknown License)  
+Copyright (C) 2001-2017 NLTK Project (ImprovedPennTokenizer, Apache 2)   
+Copyright (C) 1995 Robert MacIntyre (PennTokenizer, Unknown License)  
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@ limitations under the License.
 
 --------------------------
 
-The licensing situation re: the PennTokeniser is currently unclear.
+The licensing situation re: the PennTokenizer is currently unclear.
 See https://github.com/nltk/nltk/issues/1756
-This disclarity propergates to the ImprovedPennTokeniser, which we take from NLTK,
-which was originally based on the Penn Tokeniser.
+This disclarity propergates to the ImprovedPennTokenizer, which we take from NLTK,
+which was originally based on the PennTokenizer.
 
 > by Robert MacIntyre, University of Pennsylvania, late 1995.
 > If this wasn't such a trivial program, I'd include all that stuff about

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
-Copyright (C) 2001-2017 Lyndon White aka @oxinabox (Everything else, Apache 2)  
-Copyright (C) 2001-2017 NLTK Project (ImprovedPennTokenizer, Apache 2)   
-Copyright (C) 1995 Robert MacIntyre (PennTokenizer, Unknown License)  
+Copyright (C) 2001-2017 Lyndon White aka @oxinabox (Everything else, Apache 2)
+Copyright (C) 2001-2017 NLTK Project (ImprovedPennTokenizer, Apache 2)
+Copyright (C) 1995 Robert MacIntyre (PennTokenizer, Unknown License)
 
 Licensed under the Apache License, Version 2.0 (the 'License');
 you may not use this file except in compliance with the License.
@@ -16,9 +16,9 @@ limitations under the License.
 
 --------------------------
 
-The licensing situation re: the PennTokenizer is currently unclear.
-See https://github.com/nltk/nltk/issues/1756
-This disclarity propergates to the ImprovedPennTokenizer, which we take from NLTK,
+The licensing situation regarding the PennTokenizer is currently unclear.
+See https://github.com/nltk/nltk/issues/1756.
+This disclarity propagates to the ImprovedPennTokenizer, which we take from NLTK,
 which was originally based on the PennTokenizer.
 
 > by Robert MacIntyre, University of Pennsylvania, late 1995.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# WordTokenisers
+# WordTokenizers
 Some basic tokenizers for Natural Language Processing:
 
 The normal way to used this package is to call
@@ -55,10 +55,10 @@ String[" I ", " cannot ", " stand ", " when ", " they ", " say ", " \"", " Enoug
 The word tokenizers basically assume sentence splitting has already been done.
 
  - **Poorman's tokenizer:** (`poormans_tokenize`) Deletes all punctuation, and splits on spaces. (In some ways worse than just using `split`)
- - **Punctuation space tokenize:** (`punctuation_space_tokenize`) Marginally improved version of the poorman's tokeniser, only deletes punctuation occurring outside words.
+ - **Punctuation space tokenize:** (`punctuation_space_tokenize`) Marginally improved version of the poorman's tokenizer, only deletes punctuation occurring outside words.
 
- - **Penn Tokeniser:** (`penn_tokenize`) This is Robert MacIntyre's orginal tokeniser used for the Penn Treebank. Splits contractions.
- - **Improved Penn Tokeniser:** (`improved_penn_tokenize`) NLTK's improved Penn Treebank Tokenizer. Very similar to the original, some improvements on punctuation and contractions. This matches to NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
+ - **Penn Tokenizer:** (`penn_tokenize`) This is Robert MacIntyre's orginal tokenizer used for the Penn Treebank. Splits contractions.
+ - **Improved Penn Tokenizer:** (`improved_penn_tokenize`) NLTK's improved Penn Treebank Tokenizer. Very similar to the original, some improvements on punctuation and contractions. This matches to NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
  - **NLTK Word tokenizer:** (`nltk_word_tokenize`) NLTK's even more improved version of the Penn Tokenizer. This version has better unicode handling and some other changes. This matches to the most commonly used `nltk.word_tokenize`, minus the sentence tokenizing step. **(default tokenizer)**
 
   (To me it seems like a weird historical thing that NLTK has 2 successive variation on improving the Penn tokenizer, but for now I am matching it and having both.  See [[NLTK#2005]](https://github.com/nltk/nltk/issues/2005))
@@ -75,8 +75,8 @@ We currently only have one sentence splitter.
 # Example
 
 ```julia
-julia> tokenize("The package's tokenisers range from simple (e.g. poorman's), to complex (e.g. Penn).") |> print
-SubString{String}["The", "package", "'s", "tokenisers", "range", "from", "simple", "(", "e.g.", "poorman", "'s", ")",",", "to", "complex", "(", "e.g.", "Penn", ")", "."]
+julia> tokenize("The package's tokenizers range from simple (e.g. poorman's), to complex (e.g. Penn).") |> print
+SubString{String}["The", "package", "'s", "tokenizers", "range", "from", "simple", "(", "e.g.", "poorman", "'s", ")",",", "to", "complex", "(", "e.g.", "Penn", ")", "."]
 ```
 
 ```julia

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -50,7 +50,7 @@ end
 Yeah, sure" quote Robert MacIntyre
 
 
-Tokenisation does a number of things like seperate out contractions:
+Tokenization does a number of things like seperate out contractions:
 "shouldn't" becomes ["should", "n't"]
 Most other punctuation becomes &'s.
 Exception is periods which are not touched.
@@ -88,7 +88,7 @@ that I don't think are actually documented anywhere.
 But things like `cannot cannot` become `can not can not`
 where as the original would produce `can not cannot`.
 
-The tokeniser still seperates out contractions:
+The tokenizer still seperates out contractions:
 "shouldn't" becomes ["should", "n't"]
 
 The input should be a single sentence;
@@ -107,7 +107,7 @@ end
 """
     nltk_word_tokenize(input::AbstractString)
 
-NLTK's word tokeniser.
+NLTK's word tokenizer.
 It is an extention on the Punctuation Preserving Penn Treebank tokenizer,
 mostly to better handle unicode.
 
@@ -115,7 +115,7 @@ mostly to better handle unicode.
 Punctuation is still preserved as its own token.
 This includes periods which will be stripped from words.
 
-The tokeniser still seperates out contractions:
+The tokenizer still seperates out contractions:
 "shouldn't" becomes ["should", "n't"]
 
 The input should be a single sentence;


### PR DESCRIPTION
Plus some minor fixes in LICENSE.md