### PR TITLE
Make sed-based tokenisers 30x faster

### DIFF
--- a/src/WordTokenizers.jl
+++ b/src/WordTokenizers.jl
@@ -7,6 +7,7 @@ export poormans_tokenize, punctuation_space_tokenize,
        split_sentences,
        set_tokenizer, set_sentence_splitter
 
+include("words/fast.jl")
 include("words/simple.jl")
 include("words/sedbased.jl")
 include("sentences/sentence_splitting.jl")

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -58,7 +58,7 @@ function atoms(ts, as)
     ts.idx += length(a)
     return true
   end
-  (ispunct(ts[]) && ts[] != '.') || return false
+  (ispunct(ts[]) && ts[] != '.' && ts[] != '-') || return false
   flush!(ts, string(ts[]))
   ts.idx += 1
   return true

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -108,28 +108,3 @@ function number(ts, sep = (':', ',', '\'', '.'))
   ts.idx = i
   return true
 end
-
-const nltk_atoms = collect.(["--", "...", "``", "\$"])
-const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])
-const nltk_splits = [("cannot", 3), ("gimme", 3), ("lemme", 3), ("mor'n", 3),
-                     ("d'ye", 3), ("gonna", 3), ("gotta", 3), ("wanna", 3),
-                     ("'tis", 2), ("'twas", 2)]
-
-function nltk_word_tokenize(input)
-  ts = TokenBuffer(input)
-  stop = ts.input[end] == '.'
-  stop && pop!(ts.input)
-  while !isdone(ts)
-    spaces(ts) && continue
-    openquote(ts) ||
-    suffixes(ts, nltk_suffixes) ||
-    atoms(ts, nltk_atoms) ||
-    splits(ts, nltk_splits) ||
-    number(ts) ||
-    character(ts)
-    !isdone(ts) && closingquote(ts)
-  end
-  flush!(ts)
-  stop && push!(ts.tokens, ".")
-  return ts.tokens
-end

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -9,7 +9,7 @@ end
 
 TokenBuffer(input) = TokenBuffer(input, [], [], 1)
 
-TokenBuffer(input::String) = TokenBuffer(collect(input))
+TokenBuffer(input::AbstractString) = TokenBuffer(collect(input))
 
 Base.getindex(ts::TokenBuffer, i = ts.idx) = ts.input[i]
 isdone(ts::TokenBuffer) = ts.idx > length(ts.input)

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -136,7 +136,7 @@ function suffixes(ts, ss)
 end
 
 """
-    suffixes(::TokenBuffer, [("cannot", 3), ("gimme", 3), ...])
+    splits(::TokenBuffer, [("cannot", 3), ("gimme", 3), ...])
 
 Matches tokens that should be split at the given index. For example, `cannot`
 would be split into `can` and `not`.

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -89,6 +89,18 @@ function closingquote(ts)
   return true
 end
 
+function number(ts, sep = (':', ',', '\'', '.'))
+  isdigit(ts[]) || return false
+  i = ts.idx
+  while i <= length(ts.input) && (isdigit(ts[i]) ||
+        (ts[i] in sep && i < length(ts.input) && isdigit(ts[i+1])))
+    i += 1
+  end
+  flush!(ts, String(ts[ts.idx:i-1]))
+  ts.idx = i
+  return true
+end
+
 const nltk_atoms = collect.(["--", "...", "``"])
 const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])
 
@@ -99,9 +111,12 @@ function nltk_word_tokenize(input)
     openquote(ts) ||
     suffixes(ts, nltk_suffixes) ||
     atoms(ts, nltk_atoms) ||
+    number(ts) ||
     character(ts)
     !isdone(ts) && closingquote(ts)
   end
   flush!(ts)
   return ts.tokens
 end
+
+# nltk_word_tokenize("\$50,000 dollars")

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -106,6 +106,8 @@ const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])
 
 function nltk_word_tokenize(input)
   ts = TokenBuffer(input)
+  stop = ts.input[end] == '.'
+  stop && pop!(ts.input)
   while !isdone(ts)
     spaces(ts) && continue
     openquote(ts) ||
@@ -116,7 +118,6 @@ function nltk_word_tokenize(input)
     !isdone(ts) && closingquote(ts)
   end
   flush!(ts)
+  stop && push!(ts.tokens, ".")
   return ts.tokens
 end
-
-# nltk_word_tokenize("\$50,000 dollars")

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -1,0 +1,71 @@
+# opening quote => ``
+# closing quote => ''
+# alone: -- ... `` ' : ; @#$%&?[](){}<>
+# preserve : , ' in digits
+# split: can-not, gim-me, lem-me, mor'n, d'ye, gon-na, got-ta, wan-na, 't-is, 't-was,
+#   'll, 're, 've, n't, 's, 'm, 'd
+
+struct TokenBuffer
+  tokens::Vector{String}
+  buffer::Vector{Char}
+end
+
+TokenBuffer() = TokenBuffer([], [])
+
+function shift!(ts::TokenBuffer)
+  isempty(ts.buffer) && return
+  push!(ts.tokens, String(ts.buffer))
+  empty!(ts.buffer)
+  return
+end
+
+# TODO check for a word boundary
+function matches(input::AbstractVector, s::String, i::Integer)
+  for j = 1:length(s)
+    input[i+j-1] == s[j] || return false
+  end
+  return true
+end
+
+const tokens = ["--", "...", "``"]
+const suffixes = ["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"]
+
+function nltk_word_tokenize(input::AbstractVector)
+  ts = TokenBuffer()
+  i = 1
+  while i <= length(input)
+    if !isempty(ts.buffer)
+      for suf in suffixes
+        matches(input, suf, i) || continue
+        shift!(ts)
+        push!(ts.tokens, suf)
+        i += length(suf)
+      end
+    end
+    c = input[i]
+    if c == '"'
+      shift!(ts)
+      push!(ts.tokens, "``")
+    elseif ispunct(c)
+      shift!(ts)
+      push!(ts.tokens, string(c))
+    elseif isspace(c)
+      shift!(ts)
+    else
+      push!(ts.buffer, c)
+    end
+    # Closing quotes
+    if !isspace(c) && i < length(input) && input[i+1] == '"'
+      shift!(ts)
+      push!(ts.tokens, "''")
+      i += 1
+    end
+    i += 1
+  end
+  shift!(ts)
+  return ts.tokens
+end
+
+# @btime nltk_word_tokenize("I don't know Dr. Who.")
+
+nltk_word_tokenize(input::AbstractString) = nltk_word_tokenize(collect(input))

--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -101,7 +101,7 @@ function number(ts, sep = (':', ',', '\'', '.'))
   return true
 end
 
-const nltk_atoms = collect.(["--", "...", "``"])
+const nltk_atoms = collect.(["--", "...", "``", "\$"])
 const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])
 
 function nltk_word_tokenize(input)

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -133,6 +133,7 @@ This matches to the most commonly used `nltk.word_tokenize`, minus the sentence 
 """
 function nltk_word_tokenize(input)
   ts = TokenBuffer(input)
+  isempty(input) && return ts.tokens
   stop = ts.input[end] == '.'
   stop && pop!(ts.input)
   while !isdone(ts)

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -102,15 +102,18 @@ This matches NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
     generate_tokenizer_from_sed(script, true)
 end
 
-
+const nltk_atoms = collect.(["--", "...", "``", "\$"])
+const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])
+const nltk_splits = [("cannot", 3), ("gimme", 3), ("lemme", 3), ("mor'n", 3),
+                     ("d'ye", 3), ("gonna", 3), ("gotta", 3), ("wanna", 3),
+                     ("'tis", 2), ("'twas", 2)]
 
 """
-    nltk_word_tokenize(input::AbstractString)
+    nltk_word_tokenize(input)
 
 NLTK's word tokenizer.
-It is an extention on the Punctuation Preserving Penn Treebank tokenizer,
+It is an extension on the Punctuation Preserving Penn Treebank tokenizer,
 mostly to better handle unicode.
-
 
 Punctuation is still preserved as its own token.
 This includes periods which will be stripped from words.
@@ -124,7 +127,21 @@ Depends exactly what you want it for.
 
 This matches to the most commonly used `nltk.word_tokenize`, minus the sentence tokenizing step.
 """
-# @generated function nltk_word_tokenize(input::AbstractString)
-#     script = joinpath(@__DIR__, "nltk_word.sed")
-#     generate_tokenizer_from_sed(script, true)
-# end
+function nltk_word_tokenize(input)
+  ts = TokenBuffer(input)
+  stop = ts.input[end] == '.'
+  stop && pop!(ts.input)
+  while !isdone(ts)
+    spaces(ts) && continue
+    openquote(ts) ||
+    suffixes(ts, nltk_suffixes) ||
+    atoms(ts, nltk_atoms) ||
+    splits(ts, nltk_splits) ||
+    number(ts) ||
+    character(ts)
+    !isdone(ts) && closingquote(ts)
+  end
+  flush!(ts)
+  stop && push!(ts.tokens, ".")
+  return ts.tokens
+end

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -34,8 +34,8 @@ function generate_tokenizer_from_sed(sed_script, extended=false)::Expr
 
         push!(code.args, :(
             ss=replace(ss,
-                       Regex($pattern) =>
-                       Base.SubstitutionString($replacement))
+                       $(Regex(pattern)) =>
+                       $(Base.SubstitutionString(replacement)))
         ))
     end
     push!(code.args, :(split(ss)))

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -124,7 +124,7 @@ Depends exactly what you want it for.
 
 This matches to the most commonly used `nltk.word_tokenize`, minus the sentence tokenizing step.
 """
-@generated function nltk_word_tokenize(input::AbstractString)
-    script = joinpath(@__DIR__, "nltk_word.sed")
-    generate_tokenizer_from_sed(script, true)
-end
+# @generated function nltk_word_tokenize(input::AbstractString)
+#     script = joinpath(@__DIR__, "nltk_word.sed")
+#     generate_tokenizer_from_sed(script, true)
+# end

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -71,9 +71,10 @@ You can generate a new tokenizer using:
 end
 ```
 """
-@generated function penn_tokenize(input::AbstractString)
-    script = joinpath(@__DIR__, "penn.sed")
-    generate_tokenizer_from_sed(script, false)
+let script = joinpath(@__DIR__, "penn.sed")
+    @eval function penn_tokenize(input::AbstractString)
+        $(generate_tokenizer_from_sed(script, false))
+    end
 end
 
 
@@ -97,9 +98,10 @@ Depends exactly what you want it for.
 
 This matches NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
 """
-@generated function improved_penn_tokenize(input::AbstractString)
-    script = joinpath(@__DIR__, "improved_penn.sed")
-    generate_tokenizer_from_sed(script, true)
+let script = joinpath(@__DIR__, "improved_penn.sed")
+    @eval function improved_penn_tokenize(input::AbstractString)
+        $(generate_tokenizer_from_sed(script, true))
+    end
 end
 
 const nltk_atoms = collect.(["--", "...", "``", "\$"])

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -43,6 +43,12 @@ function generate_tokenizer_from_sed(sed_script, extended=false)::Expr
 end
 
 
+let script = joinpath(@__DIR__, "penn.sed")
+    @eval function penn_tokenize(input::AbstractString)
+        $(generate_tokenizer_from_sed(script, false))
+    end
+end
+
 """
     penn_tokenize(input::AbstractString)
 
@@ -71,13 +77,13 @@ You can generate a new tokenizer using:
 end
 ```
 """
-let script = joinpath(@__DIR__, "penn.sed")
-    @eval function penn_tokenize(input::AbstractString)
-        $(generate_tokenizer_from_sed(script, false))
+penn_tokenize
+
+let script = joinpath(@__DIR__, "improved_penn.sed")
+    @eval function improved_penn_tokenize(input::AbstractString)
+        $(generate_tokenizer_from_sed(script, true))
     end
 end
-
-
 
 """
     improved_penn_tokenize(input::AbstractString)
@@ -98,11 +104,7 @@ Depends exactly what you want it for.
 
 This matches NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
 """
-let script = joinpath(@__DIR__, "improved_penn.sed")
-    @eval function improved_penn_tokenize(input::AbstractString)
-        $(generate_tokenizer_from_sed(script, true))
-    end
-end
+improved_penn_tokenize
 
 const nltk_atoms = collect.(["--", "...", "``", "\$"])
 const nltk_suffixes = collect.(["'ll", "'re", "'ve", "n't", "'s", "'m", "'d"])

--- a/src/words/sedbased.jl
+++ b/src/words/sedbased.jl
@@ -134,7 +134,8 @@ This matches to the most commonly used `nltk.word_tokenize`, minus the sentence 
 function nltk_word_tokenize(input)
   ts = TokenBuffer(input)
   isempty(input) && return ts.tokens
-  stop = ts.input[end] == '.'
+  stop = ts.input[end] == '.' # `.` is usually absorbed into tokens (`Dr.`)
+                              # Treat the last `.` specially.
   stop && pop!(ts.input)
   while !isdone(ts)
     spaces(ts) && continue
@@ -146,7 +147,6 @@ function nltk_word_tokenize(input)
     character(ts)
     !isdone(ts) && closingquote(ts)
   end
-  flush!(ts)
   stop && push!(ts.tokens, ".")
   return ts.tokens
 end


### PR DESCRIPTION
Bet that made you look.

Right now this package compiles regexes and substitution strings on every call, which is obviously not great for performance. Avoiding this brings times down from ~300μs to ~10μs on my machine.

Given how simple the substitutions are we could likely get (at least) another order of magnitude by compiling code to do everything in one pass, rather than regexing the whole string ~10 times over.