### PR TITLE
fix names

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The word tokenizers basically assume sentence splitting has already been done.
  - **Penn Tokenizer:** (`penn_tokenize`) This is Robert MacIntyre's orginal tokenizer used for the Penn Treebank. Splits contractions.
  - **Improved Penn Tokenizer:** (`improved_penn_tokenize`) NLTK's improved Penn Treebank Tokenizer. Very similar to the original, some improvements on punctuation and contractions. This matches to NLTK's `nltk.tokenize.TreeBankWordTokenizer.tokenize`
  - **NLTK Word tokenizer:** (`nltk_word_tokenize`) NLTK's even more improved version of the Penn Tokenizer. This version has better unicode handling and some other changes. This matches to the most commonly used `nltk.word_tokenize`, minus the sentence tokenizing step. **(default tokenizer)**
-- **Reversible Tokenizer:** (`rev_tokenizer` and `rev_detokenizer`) This tokenizer splits on punctuations, space and special symbols. The generated tokens can be de-tokenized by using the `rev_detokenizer` function into the state before tokenization. 
+- **Reversible Tokenizer:** (`rev_tokenize` and `rev_detokenize`) This tokenizer splits on punctuations, space and special symbols. The generated tokens can be de-tokenized by using the `rev_detokenizer` function into the state before tokenization. 
 
 
   (To me it seems like a weird historical thing that NLTK has 2 successive variation on improving the Penn tokenizer, but for now I am matching it and having both.  See [[NLTK#2005]](https://github.com/nltk/nltk/issues/2005))

--- a/src/WordTokenizers.jl
+++ b/src/WordTokenizers.jl
@@ -7,7 +7,7 @@ export poormans_tokenize, punctuation_space_tokenize,
        rulebased_split_sentences,
        split_sentences,
        set_tokenizer, set_sentence_splitter,
-       rev_tokenizer, rev_detokenizer
+       rev_tokenize, rev_detokenize
 
 include("words/simple.jl")
 include("words/sedbased.jl")

--- a/src/reversible_tokenize.jl
+++ b/src/reversible_tokenize.jl
@@ -3,8 +3,8 @@
 A simple reversible tokenizer
 
 ```
-tokenized = rev_tokenizer(instring)
-de_tokenized = rev_detokenizer(token)
+tokenized = rev_tokenize(instring)
+de_tokenized = rev_detokenize(token)
 ```
 
 The rev_tokenize tokenizer splits into token based on space, punctuations and special symbols and in 
@@ -38,7 +38,7 @@ function nth_ind(instring, startind, n)
 end
 
 
-function rev_tokenizer(instring::AbstractString)
+function rev_tokenize(instring::AbstractString)
     ans = IOBuffer()
     for ind in eachindex(instring)
         c   = instring[thisind(instring, ind)]
@@ -62,7 +62,7 @@ function rev_tokenizer(instring::AbstractString)
 end
 
 
-function rev_detokenizer(instring::Array{String})
+function rev_detokenize(instring::Array{String})
     ind = 1
     ans = IOBuffer()
     instring = join(instring, " ")

--- a/test/reversible_tok.jl
+++ b/test/reversible_tok.jl
@@ -5,8 +5,8 @@ using WordTokenizers
 	str = "The quick brown fox jumped over the lazy dog"                
 	tokenized = ["The", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog"]
 
-	@test tokenized == String.(rev_tokenizer(str))           
-	@test str == rev_detokenizer(tokenized)              
+	@test tokenized == String.(rev_tokenize(str))           
+	@test str == rev_detokenize(tokenized)              
 end
 
 
@@ -14,7 +14,7 @@ end
     	str = "Some of   100,000 households (usually, a minority) ate breakfast.  "
     	tokenized = ["Some", "of", "100", "\ue302,\ue302", "000", "households", "(\ue302", "usually", "\ue302,", "a", "minority", "\ue302)", "ate", "breakfast", "\ue302."]
 
-	@test tokenized == String.(rev_tokenizer(str))        
+	@test tokenized == String.(rev_tokenize(str))        
 end
 
 
@@ -22,8 +22,8 @@ end
 	str = "Some of 100,000 households (usually, a minority) ate breakfast."
 	tokenized = ["Some", "of", "100", "\ue302,\ue302", "000", "households", "(\ue302", "usually", "\ue302,", "a", "minority", "\ue302)", "ate", "breakfast", "\ue302."]
 
-	@test tokenized == String.(rev_tokenizer(str))         
-	@test str == rev_detokenizer(tokenized)                
+	@test tokenized == String.(rev_tokenize(str))         
+	@test str == rev_detokenize(tokenized)                
 end
 
 
@@ -31,6 +31,6 @@ end
 	str = "The quick brown fox jumped over the lazy dog ⌣⌣"
 	tokenized = ["The", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog", "⌣", "\ue302⌣"]
 
-	@test tokenized == String.(rev_tokenizer(str))        
-	@test str == rev_detokenizer(tokenized)
+	@test tokenized == String.(rev_tokenize(str))        
+	@test str == rev_detokenize(tokenized)
 end


### PR DESCRIPTION
Fixing the name of `rev_tokenizer` and `rev_detokenizer` to `rev_tokenize` and `rev_detokenize`, that were missed in last PR https://github.com/JuliaText/WordTokenizers.jl/pull/14
