### PR TITLE
Minor doc fixes in fast.jl

### DIFF
--- a/src/words/fast.jl
+++ b/src/words/fast.jl
@@ -198,7 +198,7 @@ function openquote(ts)
 end
 
 """
-    openquote(::TokenBuffer)
+    closingquote(::TokenBuffer)
 
 Matches " used as a closing quote, and tokenises it as ''.
 """


### PR DESCRIPTION
A minor fix in the docstrings for this function `closingquote(::TokenBuffer)`. Came across this while working on Tweet Tokenizer