### PR TITLE
Fix sentence splitter: sentences ending with acronyms

### DIFF
--- a/src/sentences/sentence_splitting.jl
+++ b/src/sentences/sentence_splitting.jl
@@ -71,7 +71,7 @@ function postproc_splits(sentences::AbstractString)
 
 
     # No break after an single letter other than I, which could be an initial in a name
-    sentences = replace(sentences, r"([A-HJ-Z]\.)\n" => s"\1 ")
+    sentences = replace(sentences, r"(\s[A-HJ-Z]\.)\n" => s"\1 ")
 
     # no break before CC ...
     sentences = replace(sentences, r"\n(and )" => s" \1")

--- a/src/sentences/sentence_splitting.jl
+++ b/src/sentences/sentence_splitting.jl
@@ -71,7 +71,7 @@ function postproc_splits(sentences::AbstractString)
 
 
     # No break after an single letter other than I, which could be an initial in a name
-    sentences = replace(sentences, r"(\s[A-HJ-Z]\.)\n" => s"\1 ")
+    sentences = replace(sentences, r"(\b[A-HJ-Z]\.)\n" => s"\1 ")
 
     # no break before CC ...
     sentences = replace(sentences, r"\n(and )" => s" \1")

--- a/test/sentence_splitting.jl
+++ b/test/sentence_splitting.jl
@@ -15,6 +15,10 @@ using WordTokenizers
     @testset "period only" begin
         @test length(rulebased_split_sentences("a good day . . Yes"))==2
     end
+
+    @testset "Acronyms" begin
+        @test length(rulebased_split_sentences("Adamson is not from USA. They are from Europe."))==2
+    end
 end
 
 

--- a/test/sentence_splitting.jl
+++ b/test/sentence_splitting.jl
@@ -6,6 +6,7 @@ using WordTokenizers
         @test 1 == length(rulebased_split_sentences("It is by A. Adamson, the famous author."))
         @test 1 == length(rulebased_split_sentences("It is by Z. Zeckerson, the famous author."))
         @test 1 == length(rulebased_split_sentences("It is by Bill R. Emerson, the famous author."))
+        @test 1 == length(rulebased_split_sentences("It is by A. A. Adamson, the famous author."))
 
         @test_broken 1 == (rulebased_split_sentences("It is by Ian I. Irving, the famous author."))
 


### PR DESCRIPTION
A sentence ending with an acronym was dot distinguished from an initial
followed by a period in the middle of the sentence. E.g., "Adamson is not from USA. 
They are from Europe" was considered as a single sentence because "USA." was 
treated as an initial.

1. Added a requirement for the initial to be only one letter long: "A." in "A. 
Adamson" is still treated as an initial, while "USA" in "from USA. They" is not.
2. Added a test for such case.