### PR TITLE
Filtering the empty strings from substring array

### DIFF
--- a/src/sentences/sentence_splitting.jl
+++ b/src/sentences/sentence_splitting.jl
@@ -1,8 +1,8 @@
 function rulebased_split_sentences(sentences)
     sentences = replace(sentences, r"([?!.])\s" => Base.SubstitutionString("\\1\n"))
-
     sentences = postproc_splits(sentences)
-    split(sentences, "\n")
+    sentences = split(sentences, "\n")
+    filter!(e-> e ≠ "", sentences)
 end
 
 
@@ -37,7 +37,6 @@ medss.pl script.
 function postproc_splits(sentences::AbstractString)
     # Before we do anything remove windows line-ends
     sentences = replace(sentences, "\r" => "")
-
 
     # breaks sometimes missing after "?", "safe" cases
     sentences = replace(sentences, r"\b([a-z]+\?) ([A-Z][a-z]+)\b" => Base.SubstitutionString("\\1\n\\2"))

--- a/src/sentences/sentence_splitting.jl
+++ b/src/sentences/sentence_splitting.jl
@@ -1,10 +1,9 @@
 function rulebased_split_sentences(sentences)
     sentences = replace(sentences, r"([?!.])\s" => Base.SubstitutionString("\\1\n"))
-    sentences = postproc_splits(sentences)
-    sentences = split(sentences, "\n")
-    filter!(e-> e ≠ "", sentences)
-end
 
+    sentences = postproc_splits(sentences)
+    split(sentences, "\n"; keepempty=false)
+end
 
 
 function replace_til_no_change(input, pattern, replacement)


### PR DESCRIPTION
It's easy Removing the Empty string created in the final array. It's very hard to implement the function like .strip() in here because we are just substituting the strings in place of delimiters.